### PR TITLE
Make the jump commands wrap around

### DIFF
--- a/pythonx/coverage_highlight.py
+++ b/pythonx/coverage_highlight.py
@@ -203,40 +203,29 @@ class Signs(object):
         return None
 
     def find_next_range(self, line):
-        # Rewrite using self.iter_ranges() maybe?
-        signs = iter(self)
-        for sign in signs:
-            if sign['lnum'] == line:
-                line += 1
-            if sign['lnum'] > line:
-                break
-        else:
-            return None
-        first = last = sign['lnum']
-        for sign in signs:
-            if sign['lnum'] == last + 1:
-                last += 1
-        return first, last
+        first_range = None
+        for first, last in self.iter_ranges():
+            if first_range is None:
+                first_range = (first, last)
+            if line < first:
+                return (first, last)
+        if first_range is not None and first_range[1] < line:
+            return first_range
+        return None
 
     def find_prev_range(self, line):
-        # Rewrite using self.iter_ranges() maybe?
-        signs = iter(self)
         prev_range = None
-        first = last = None
-        for sign in signs:
-            if last is None:
-                first = last = sign['lnum']
-            elif sign['lnum'] == last + 1:
-                last += 1
-            else:
+        last_range = None
+        for first, last in self.iter_ranges():
+            if last < line:
                 prev_range = (first, last)
-                first = last = sign['lnum']
-            if sign['lnum'] >= line:
-                break
+            last_range = (first, last)
+        if prev_range is not None:
+            return prev_range
+        elif last_range is not None and line < last_range[0]:
+            return last_range
         else:
-            if last is not None:
-                prev_range = (first, last)
-        return prev_range
+            return None
 
 
 def lazyredraw(fn):

--- a/pythonx/coverage_highlight.py
+++ b/pythonx/coverage_highlight.py
@@ -203,29 +203,26 @@ class Signs(object):
         return None
 
     def find_next_range(self, line):
-        first_range = None
         for first, last in self.iter_ranges():
-            if first_range is None:
-                first_range = (first, last)
             if line < first:
                 return (first, last)
-        if first_range is not None and first_range[1] < line:
-            return first_range
         return None
 
     def find_prev_range(self, line):
         prev_range = None
-        last_range = None
         for first, last in self.iter_ranges():
             if last < line:
                 prev_range = (first, last)
-            last_range = (first, last)
-        if prev_range is not None:
-            return prev_range
-        elif last_range is not None and line < last_range[0]:
-            return last_range
-        else:
-            return None
+        return prev_range
+
+    def find_first_range(self):
+        return next(self.iter_ranges(), None)
+
+    def find_last_range(self):
+        last_range = None
+        for first, last in self.iter_ranges():
+            last_range = first, last
+        return last_range
 
 
 def lazyredraw(fn):
@@ -499,14 +496,22 @@ def jump_to_next():
     next_range = signs.find_next_range(row)
     if next_range is None:
         current_range = signs.find_current_range(row)
-        if current_range is not None:
-            # if we're at the very last range, jump to the last line
-            first, last = current_range
-            if row != last:
-                vim.command("normal! %dG" % last)
+        if vim.eval("&wrapscan"):
+            next_range = signs.find_first_range()
+            if next_range is None:
+                print("No highlighted lines in buffer")
                 return
-        print("No highlighted lines below cursor")
-        return
+            elif next_range == current_range:
+                next_range = None
+        if next_range is None:
+            if current_range is not None:
+                # if we're at the very last range, jump to the last line
+                first, last = current_range
+                if row != last:
+                    vim.command("normal! %dG" % last)
+                    return
+            print("No highlighted lines below cursor")
+            return
     first, last = next_range
     # jump to last line so it's visible, then jump back to 1st line
     # (this does not always work the way I want but eh)
@@ -521,14 +526,22 @@ def jump_to_prev():
     prev_range = signs.find_prev_range(row)
     if prev_range is None:
         current_range = signs.find_current_range(row)
-        if current_range is not None:
-            # if we're at the very first range, jump to the first line
-            first, last = current_range
-            if row != first:
-                vim.command("normal! %dG" % first)
+        if vim.eval("&wrapscan"):
+            prev_range = signs.find_last_range()
+            if prev_range is None:
+                print("No highlighted lines in buffer")
                 return
-        print("No highlighted lines above cursor")
-        return
+            elif prev_range == current_range:
+                prev_range = None
+        if prev_range is None:
+            if current_range is not None:
+                # if we're at the very first range, jump to the first line
+                first, last = current_range
+                if row != first:
+                    vim.command("normal! %dG" % first)
+                    return
+            print("No highlighted lines above cursor")
+            return
     first, last = prev_range
     # jump to first line so it's visible, then jump back to last line
     # (this does not always work the way I want but eh)


### PR DESCRIPTION
This PR modifies the `:NextUncovered` command so that, when it is invoked when the cursor is after the last uncovered block, the cursor moves to the first uncovered block, and similarly for `:PrevUncovered`.  The PR also fixes a typo in the message previously shown when there are no uncovered lines below/above the current line (now only shown when there are no uncovered lines in the whole file, or when at the last/first line of the only uncovered block).