### PR TITLE
Support environments that use skip_covered

### DIFF
--- a/pythonx/coverage_highlight.py
+++ b/pythonx/coverage_highlight.py
@@ -400,6 +400,8 @@ def find_coverage_script():
 def find_coverage_file_for(filename):
     if os.path.exists('.coverage'):
         return '.'
+    elif os.path.exists('.tox/.coverage'):
+        return '.tox'
     where = os.path.dirname(filename)
     while True:
         if os.path.exists(os.path.join(where, '.coverage')):
@@ -422,7 +424,7 @@ def run_coverage_report(coverage_script, coverage_dir, args=[]):
     else:
         # things like "python3 -m coverage"
         command = shlex.split(coverage_script)
-    output = subprocess.Popen(command + ['report', '-m'] + args,
+    output = subprocess.Popen(command + ['report', '--no-skip-covered', '-m'] + args,
                               stdout=subprocess.PIPE,
                               stderr=subprocess.STDOUT,
                               cwd=coverage_dir).communicate()[0]


### PR DESCRIPTION
Also look in one other location for a common `.coverage` file -- if you combine coverage from integration tests or runs on multiple python versions, this seems a common place to store it, e.g. on
https://github.com/codrsquad/runez/blob/c614471e706d12ac21d94c8d8aceda864543107b/tox.ini#L12

The only other configuration option that I considered overriding is fail-under, but it looks like this doesn't take effect when you specify a filename.  Good.